### PR TITLE
Private docker images support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * Added `region` to `railway_service`
 * Added `num_replicas` to `railway_service`
+* Added registry credentials to `railway_service`
 
 ## 0.4.0
 

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -38,6 +38,8 @@ resource "railway_service" "example" {
 - `region` (String) Region to deploy service in. **Default** `us-west1`.
 - `root_directory` (String) Directory to user for the service. Conflicts with `source_image`.
 - `source_image` (String) Source image of the service. Conflicts with `source_repo`, `source_repo_branch`, `root_directory` and `config_path`.
+- `source_image_registry_password` (String, Sensitive) Private Docker registry credentials.
+- `source_image_registry_username` (String) Private Docker registry credentials.
 - `source_repo` (String) Source repository of the service. Conflicts with `source_image`.
 - `source_repo_branch` (String) Source repository branch to be used with `source_repo`. Must be specified if `source_repo` is specified.
 - `volume` (Attributes) Volume connected to the service. (see [below for nested schema](#nestedatt--volume))

--- a/internal/provider/generated.go
+++ b/internal/provider/generated.go
@@ -269,7 +269,7 @@ type ProjectCreateInput struct {
 	Plugins                []string           `json:"plugins"`
 	PrDeploys              bool               `json:"prDeploys"`
 	Repo                   *ProjectCreateRepo `json:"repo"`
-	Runtime                PublicRuntime      `json:"runtime"`
+	Runtime                *PublicRuntime     `json:"runtime"`
 	TeamId                 *string            `json:"teamId"`
 }
 
@@ -295,7 +295,7 @@ func (v *ProjectCreateInput) GetPrDeploys() bool { return v.PrDeploys }
 func (v *ProjectCreateInput) GetRepo() *ProjectCreateRepo { return v.Repo }
 
 // GetRuntime returns ProjectCreateInput.Runtime, and is useful for accessing the field via an interface.
-func (v *ProjectCreateInput) GetRuntime() PublicRuntime { return v.Runtime }
+func (v *ProjectCreateInput) GetRuntime() *PublicRuntime { return v.Runtime }
 
 // GetTeamId returns ProjectCreateInput.TeamId, and is useful for accessing the field via an interface.
 func (v *ProjectCreateInput) GetTeamId() *string { return v.TeamId }

--- a/internal/provider/resource_project.graphql
+++ b/internal/provider/resource_project.graphql
@@ -26,6 +26,7 @@ query getProject($id: String!) {
 }
 
 # @genqlient(for: "ProjectCreateInput.teamId", pointer: true)
+# @genqlient(for: "ProjectCreateInput.runtime", pointer: true)
 # @genqlient(for: "ProjectCreateInput.repo", pointer: true)
 mutation createProject(
   $input: ProjectCreateInput!


### PR DESCRIPTION
Hey guys!

Recently introduced Private docker image support: https://railway.app/changelog/2024-03-15-template-composer
I was able communicate with them, so they kindly provided a way use pass credentials for private docker registries over public API. 

This PR is actually makes this possible using Terraform.

# In regards of PR
- actual changes I made are just [that](https://github.com/terraform-community-providers/terraform-provider-railway/pull/26/files#diff-faeca4b7b0e45e83cf08e7e8205591b7eb2f18d3986e3b81836c9603d335ef9f)
- all the rest is pulling fresh GraphQL SDL and regenerating data types just a little bit

# Note
- unfortunately private docker registry support is only available for Pro plan users. It is restriction of Railway, not Terraform provider