### PR TITLE
Service region and numreplicas support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## master
+
+### Enhancements
+* Added `region` to `railway_service`
+* Added `num_replicas` to `railway_service`
+
 ## 0.4.0
 
 ### BREAKING
@@ -6,7 +12,7 @@
 ## 0.3.1
 
 ### Bug fixes
-* Fix issue with replicas of a service being set to `0`.
+* Fix issue with replicas of a service being set to `0`
 
 ## 0.3.0
 

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -34,6 +34,8 @@ resource "railway_service" "example" {
 
 - `config_path` (String) Path to the Railway config file. Conflicts with `source_image`.
 - `cron_schedule` (String) Cron schedule of the service.
+- `num_replicas` (Number) Number of replicas to deploy. **Default** `1`.
+- `region` (String) Region to deploy service in. **Default** `us-west1`.
 - `root_directory` (String) Directory to user for the service. Conflicts with `source_image`.
 - `source_image` (String) Source image of the service. Conflicts with `source_repo`, `source_repo_branch`, `root_directory` and `config_path`.
 - `source_repo` (String) Source repository of the service. Conflicts with `source_image`.

--- a/internal/provider/generated.go
+++ b/internal/provider/generated.go
@@ -559,22 +559,22 @@ func (v *ServiceDomainUpdateInput) GetServiceId() string { return v.ServiceId }
 func (v *ServiceDomainUpdateInput) GetTargetPort() int { return v.TargetPort }
 
 type ServiceInstanceUpdateInput struct {
-	BuildCommand            *string                  `json:"buildCommand,omitempty"`
-	Builder                 *Builder                 `json:"builder,omitempty"`
-	CronSchedule            *string                  `json:"cronSchedule"`
-	HealthcheckPath         *string                  `json:"healthcheckPath,omitempty"`
-	HealthcheckTimeout      *int                     `json:"healthcheckTimeout,omitempty"`
-	NixpacksPlan            *map[string]interface{}  `json:"nixpacksPlan,omitempty"`
-	NumReplicas             *int                     `json:"numReplicas,omitempty"`
-	RailwayConfigFile       string                   `json:"railwayConfigFile"`
-	Region                  *string                  `json:"region,omitempty"`
-	RegistryCredentials     RegistryCredentialsInput `json:"registryCredentials"`
-	RestartPolicyMaxRetries *int                     `json:"restartPolicyMaxRetries,omitempty"`
-	RestartPolicyType       *RestartPolicyType       `json:"restartPolicyType,omitempty"`
-	RootDirectory           string                   `json:"rootDirectory"`
-	Source                  *ServiceSourceInput      `json:"source,omitempty"`
-	StartCommand            *string                  `json:"startCommand,omitempty"`
-	WatchPatterns           []*string                `json:"watchPatterns"`
+	BuildCommand            *string                   `json:"buildCommand,omitempty"`
+	Builder                 *Builder                  `json:"builder,omitempty"`
+	CronSchedule            *string                   `json:"cronSchedule"`
+	HealthcheckPath         *string                   `json:"healthcheckPath,omitempty"`
+	HealthcheckTimeout      *int                      `json:"healthcheckTimeout,omitempty"`
+	NixpacksPlan            *map[string]interface{}   `json:"nixpacksPlan,omitempty"`
+	NumReplicas             int                       `json:"numReplicas"`
+	RailwayConfigFile       *string                   `json:"railwayConfigFile,omitempty"`
+	Region                  string                    `json:"region"`
+	RegistryCredentials     *RegistryCredentialsInput `json:"registryCredentials,omitempty"`
+	RestartPolicyMaxRetries *int                      `json:"restartPolicyMaxRetries,omitempty"`
+	RestartPolicyType       *RestartPolicyType        `json:"restartPolicyType,omitempty"`
+	RootDirectory           *string                   `json:"rootDirectory,omitempty"`
+	Source                  *ServiceSourceInput       `json:"source,omitempty"`
+	StartCommand            *string                   `json:"startCommand,omitempty"`
+	WatchPatterns           []*string                 `json:"watchPatterns"`
 }
 
 // GetBuildCommand returns ServiceInstanceUpdateInput.BuildCommand, and is useful for accessing the field via an interface.
@@ -596,16 +596,16 @@ func (v *ServiceInstanceUpdateInput) GetHealthcheckTimeout() *int { return v.Hea
 func (v *ServiceInstanceUpdateInput) GetNixpacksPlan() *map[string]interface{} { return v.NixpacksPlan }
 
 // GetNumReplicas returns ServiceInstanceUpdateInput.NumReplicas, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetNumReplicas() *int { return v.NumReplicas }
+func (v *ServiceInstanceUpdateInput) GetNumReplicas() int { return v.NumReplicas }
 
 // GetRailwayConfigFile returns ServiceInstanceUpdateInput.RailwayConfigFile, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetRailwayConfigFile() string { return v.RailwayConfigFile }
+func (v *ServiceInstanceUpdateInput) GetRailwayConfigFile() *string { return v.RailwayConfigFile }
 
 // GetRegion returns ServiceInstanceUpdateInput.Region, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetRegion() *string { return v.Region }
+func (v *ServiceInstanceUpdateInput) GetRegion() string { return v.Region }
 
 // GetRegistryCredentials returns ServiceInstanceUpdateInput.RegistryCredentials, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetRegistryCredentials() RegistryCredentialsInput {
+func (v *ServiceInstanceUpdateInput) GetRegistryCredentials() *RegistryCredentialsInput {
 	return v.RegistryCredentials
 }
 
@@ -620,7 +620,7 @@ func (v *ServiceInstanceUpdateInput) GetRestartPolicyType() *RestartPolicyType {
 }
 
 // GetRootDirectory returns ServiceInstanceUpdateInput.RootDirectory, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetRootDirectory() string { return v.RootDirectory }
+func (v *ServiceInstanceUpdateInput) GetRootDirectory() *string { return v.RootDirectory }
 
 // GetSource returns ServiceInstanceUpdateInput.Source, and is useful for accessing the field via an interface.
 func (v *ServiceInstanceUpdateInput) GetSource() *ServiceSourceInput { return v.Source }
@@ -2546,6 +2546,8 @@ type getServiceInstanceServiceInstance struct {
 	RootDirectory     *string                                               `json:"rootDirectory"`
 	RailwayConfigFile *string                                               `json:"railwayConfigFile"`
 	CronSchedule      *string                                               `json:"cronSchedule"`
+	Region            string                                                `json:"region"`
+	NumReplicas       int                                                   `json:"numReplicas"`
 }
 
 // GetSource returns getServiceInstanceServiceInstance.Source, and is useful for accessing the field via an interface.
@@ -2563,6 +2565,12 @@ func (v *getServiceInstanceServiceInstance) GetRailwayConfigFile() *string {
 
 // GetCronSchedule returns getServiceInstanceServiceInstance.CronSchedule, and is useful for accessing the field via an interface.
 func (v *getServiceInstanceServiceInstance) GetCronSchedule() *string { return v.CronSchedule }
+
+// GetRegion returns getServiceInstanceServiceInstance.Region, and is useful for accessing the field via an interface.
+func (v *getServiceInstanceServiceInstance) GetRegion() string { return v.Region }
+
+// GetNumReplicas returns getServiceInstanceServiceInstance.NumReplicas, and is useful for accessing the field via an interface.
+func (v *getServiceInstanceServiceInstance) GetNumReplicas() int { return v.NumReplicas }
 
 // getServiceInstanceServiceInstanceSourceServiceSource includes the requested fields of the GraphQL type ServiceSource.
 type getServiceInstanceServiceInstanceSourceServiceSource struct {
@@ -4437,6 +4445,8 @@ query getServiceInstance ($environmentId: String!, $serviceId: String!) {
 		rootDirectory
 		railwayConfigFile
 		cronSchedule
+		region
+		numReplicas
 	}
 }
 `,

--- a/internal/provider/resource_service.graphql
+++ b/internal/provider/resource_service.graphql
@@ -35,12 +35,12 @@ mutation updateService(
   }
 }
 
+# @genqlient(for: "ServiceInstance.rootDirectory", pointer: true)
+# @genqlient(for: "ServiceInstance.railwayConfigFile", pointer: true)
 # @genqlient(for: "ServiceInstance.cronSchedule", pointer: true)
 # @genqlient(for: "ServiceInstance.source", pointer: true)
 # @genqlient(for: "ServiceSource.image", pointer: true)
 # @genqlient(for: "ServiceSource.repo", pointer: true)
-# @genqlient(for: "ServiceInstance.rootDirectory", pointer: true)
-# @genqlient(for: "ServiceInstance.railwayConfigFile", pointer: true)
 query getServiceInstance(
   $environmentId: String!
   $serviceId: String!
@@ -53,15 +53,18 @@ query getServiceInstance(
     rootDirectory
     railwayConfigFile
     cronSchedule
+    region
+    numReplicas
   }
 }
 
+# @genqlient(for: "ServiceInstanceUpdateInput.rootDirectory", omitempty: true, pointer: true)
+# @genqlient(for: "ServiceInstanceUpdateInput.railwayConfigFile", omitempty: true, pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.cronSchedule", pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.watchPatterns", pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.source", omitempty: true, pointer: true)
+# @genqlient(for: "ServiceInstanceUpdateInput.registryCredentials", omitempty: true, pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.nixpacksPlan", omitempty: true, pointer: true)
-# @genqlient(for: "ServiceInstanceUpdateInput.numReplicas", omitempty: true, pointer: true)
-# @genqlient(for: "ServiceInstanceUpdateInput.region", omitempty: true, pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.builder", omitempty: true, pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.buildCommand", omitempty: true, pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.startCommand", omitempty: true, pointer: true)

--- a/internal/provider/resource_service_test.go
+++ b/internal/provider/resource_service_test.go
@@ -26,6 +26,8 @@ func TestAccServiceResourceDefault(t *testing.T) {
 					resource.TestCheckNoResourceAttr("railway_service.test", "root_directory"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "config_path"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// ImportState testing
@@ -48,6 +50,8 @@ func TestAccServiceResourceDefault(t *testing.T) {
 					resource.TestCheckNoResourceAttr("railway_service.test", "root_directory"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "config_path"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// Update and Read testing image
@@ -57,13 +61,15 @@ func TestAccServiceResourceDefault(t *testing.T) {
 					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
 					resource.TestCheckResourceAttr("railway_service.test", "name", "nue-todo-app"),
 					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
-					resource.TestCheckResourceAttr("railway_service.test", "cron_schedule", "0 0 * * *"),
+					resource.TestCheckNoResourceAttr("railway_service.test", "cron_schedule"),
 					resource.TestCheckResourceAttr("railway_service.test", "source_image", "hello-world"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "root_directory"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "config_path"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-east4"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "2"),
 				),
 			},
 			// ImportState testing
@@ -86,6 +92,8 @@ func TestAccServiceResourceDefault(t *testing.T) {
 			// 		resource.TestCheckResourceAttr("railway_service.test", "root_directory", "blog"),
 			// 		resource.TestCheckResourceAttr("railway_service.test", "config_path", "blog/railway.yaml"),
 			// 		resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+			//		resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+			//		resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 			// 	),
 			// },
 			// ImportState testing
@@ -101,7 +109,7 @@ func TestAccServiceResourceDefault(t *testing.T) {
 					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
 					resource.TestCheckResourceAttr("railway_service.test", "name", "nue-todo-app"),
 					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
-					resource.TestCheckNoResourceAttr("railway_service.test", "cron_schedule"),
+					resource.TestCheckResourceAttr("railway_service.test", "cron_schedule", "0 0 * * *"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_image"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
@@ -111,6 +119,8 @@ func TestAccServiceResourceDefault(t *testing.T) {
 					resource.TestCheckResourceAttr("railway_service.test", "volume.name", "todo-app-volume"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.mount_path", "/mnt"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.size", "50000"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -130,13 +140,15 @@ func TestAccServiceResourceNonDefaultImage(t *testing.T) {
 					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
 					resource.TestCheckResourceAttr("railway_service.test", "name", "todo-app"),
 					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
-					resource.TestCheckResourceAttr("railway_service.test", "cron_schedule", "0 0 * * *"),
+					resource.TestCheckNoResourceAttr("railway_service.test", "cron_schedule"),
 					resource.TestCheckResourceAttr("railway_service.test", "source_image", "hello-world"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "root_directory"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "config_path"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-east4"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "2"),
 				),
 			},
 			// ImportState testing
@@ -152,13 +164,15 @@ func TestAccServiceResourceNonDefaultImage(t *testing.T) {
 					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
 					resource.TestCheckResourceAttr("railway_service.test", "name", "todo-app"),
 					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
-					resource.TestCheckResourceAttr("railway_service.test", "cron_schedule", "0 0 * * *"),
+					resource.TestCheckNoResourceAttr("railway_service.test", "cron_schedule"),
 					resource.TestCheckResourceAttr("railway_service.test", "source_image", "hello-world"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "root_directory"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "config_path"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-east4"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "2"),
 				),
 			},
 			// Update with null values
@@ -175,6 +189,8 @@ func TestAccServiceResourceNonDefaultImage(t *testing.T) {
 					resource.TestCheckNoResourceAttr("railway_service.test", "root_directory"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "config_path"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// ImportState testing
@@ -207,6 +223,8 @@ func TestAccServiceResourceNonDefaultRepo(t *testing.T) {
 			// 		resource.TestCheckResourceAttr("railway_service.test", "root_directory", "blog"),
 			// 		resource.TestCheckResourceAttr("railway_service.test", "config_path", "blog/railway.yaml"),
 			// 		resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+			//		resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+			//		resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 			// 	),
 			// },
 			// // ImportState testing
@@ -229,6 +247,8 @@ func TestAccServiceResourceNonDefaultRepo(t *testing.T) {
 			// 		resource.TestCheckResourceAttr("railway_service.test", "root_directory", "blog"),
 			// 		resource.TestCheckResourceAttr("railway_service.test", "config_path", "blog/railway.yaml"),
 			// 		resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+			//		resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+			//		resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 			// 	),
 			// },
 			// Update with null values
@@ -243,6 +263,8 @@ func TestAccServiceResourceNonDefaultRepo(t *testing.T) {
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// ImportState testing
@@ -268,7 +290,7 @@ func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
 					resource.TestCheckResourceAttr("railway_service.test", "name", "todo-app"),
 					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
-					resource.TestCheckNoResourceAttr("railway_service.test", "cron_schedule"),
+					resource.TestCheckResourceAttr("railway_service.test", "cron_schedule", "0 0 * * *"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_image"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
@@ -278,6 +300,8 @@ func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 					resource.TestCheckResourceAttr("railway_service.test", "volume.name", "todo-app-volume"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.mount_path", "/mnt"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.size", "50000"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// ImportState testing
@@ -293,7 +317,7 @@ func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
 					resource.TestCheckResourceAttr("railway_service.test", "name", "todo-app"),
 					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
-					resource.TestCheckNoResourceAttr("railway_service.test", "cron_schedule"),
+					resource.TestCheckResourceAttr("railway_service.test", "cron_schedule", "0 0 * * *"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_image"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
@@ -303,6 +327,8 @@ func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 					resource.TestCheckResourceAttr("railway_service.test", "volume.name", "todo-app-volume"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.mount_path", "/mnt"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.size", "50000"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// Update with different values
@@ -312,7 +338,7 @@ func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
 					resource.TestCheckResourceAttr("railway_service.test", "name", "todo-app"),
 					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
-					resource.TestCheckNoResourceAttr("railway_service.test", "cron_schedule"),
+					resource.TestCheckResourceAttr("railway_service.test", "cron_schedule", "0 0 * * *"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_image"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "source_repo_branch"),
@@ -322,6 +348,8 @@ func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 					resource.TestCheckResourceAttr("railway_service.test", "volume.name", "data-volume"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.mount_path", "/data"),
 					resource.TestCheckResourceAttr("railway_service.test", "volume.size", "50000"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// Update with null values
@@ -338,6 +366,8 @@ func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 					resource.TestCheckNoResourceAttr("railway_service.test", "root_directory"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "config_path"),
 					resource.TestCheckNoResourceAttr("railway_service.test", "volume"),
+					resource.TestCheckResourceAttr("railway_service.test", "region", "us-west1"),
+					resource.TestCheckResourceAttr("railway_service.test", "num_replicas", "1"),
 				),
 			},
 			// ImportState testing
@@ -366,8 +396,9 @@ resource "railway_service" "test" {
   name = "%s"
   project_id = "0bb01547-570d-4109-a5e8-138691f6a2d1"
 
-  cron_schedule = "0 0 * * *"
   source_image = "hello-world"
+  region = "us-east4"
+  num_replicas = 2
 }
 `, name)
 }
@@ -391,6 +422,8 @@ func testAccServiceResourceConfigNonDefaultVolume(name string, volumeName string
 resource "railway_service" "test" {
   name = "%s"
   project_id = "0bb01547-570d-4109-a5e8-138691f6a2d1"
+
+  cron_schedule = "0 0 * * *"
 
   volume = {
     name = "%s"


### PR DESCRIPTION
## What
This PR adds support for two parameters related to a `railway_service`: `region` and `num_replicas`

## Why
To manage services based on the docker images which are not having Railway configuration file at all