### PR TITLE
Add source parameter to bypass Railway edge rate limiting

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,7 +87,7 @@ func (p *RailwayProvider) Configure(ctx context.Context, req provider.ConfigureR
 		},
 	}
 
-	client := graphql.NewClient("https://backboard.railway.app/graphql/v2", &httpClient)
+	client := graphql.NewClient("https://backboard.railway.app/graphql/v2?source=terraform_provider_railway", &httpClient)
 
 	resp.DataSourceData = &client
 	resp.ResourceData = &client


### PR DESCRIPTION
## Summary

  Add source identifier query parameter to Railway API requests to bypass Cloudflare edge rate limiting that blocks Terraform operations.

  ## Problem

  The Terraform provider regularly encounters Cloudflare Error 1015 ("You are being rate limited") when managing Railway infrastructure. This occurs at Cloudflare's edge before requests reach the Railway
  API, returning HTTP 429 without any `X-RateLimit-*` headers.

  A typical Terraform run is well below Railway's documented 50 RPS limit for the pro plan. However, Railway applies a 10 RPS Cloudflare rate limit to API requests without a query
  string parameter, as confirmed by Railway staff in [this Station thread](https://station.railway.com/questions/railway-api-cloudflare-rate-limiting-369be022).

  This makes Terraform usage unreliable and creates a significant operational blocker for teams relying on infrastructure-as-code workflows. In particular, when hitting the cloudflare edge limit further queries are blocked for a full day rather than resetting at a reasonable interval.

  ## Solution

  Add `source=terraform_provider_railway` query parameter to the GraphQL endpoint URL. This identifies traffic as originating from the Terraform provider and bypasses the 10 RPS Cloudflare edge limit.

  The change is a single-line modification to the GraphQL client initialization in `internal/provider/provider.go`.

  ## Testing

  Validated that adding the query parameter successfully bypasses Cloudflare rate limiting during typical Terraform operations (plan/apply cycles with multiple resources).

  ## Reference

  https://station.railway.com/questions/railway-api-cloudflare-rate-limiting-369be022