### PR TITLE
Fix volume creation by including environmentId parameter

### DIFF
--- a/internal/provider/resource_service.go
+++ b/internal/provider/resource_service.go
@@ -379,10 +379,17 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 			return
 		}
 
+		_, environment, err := defaultEnvironmentForProject(ctx, *r.client, data.ProjectId.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get default environment, got error: %s", err))
+			return
+		}
+
 		volumeResponse, err := createVolume(ctx, *r.client, VolumeCreateInput{
-			MountPath: volumeData.MountPath.ValueString(),
-			ProjectId: data.ProjectId.ValueString(),
-			ServiceId: data.Id.ValueStringPointer(),
+			MountPath:     volumeData.MountPath.ValueString(),
+			ProjectId:     data.ProjectId.ValueString(),
+			ServiceId:     data.Id.ValueStringPointer(),
+			EnvironmentId: &environment.Id,
 		})
 
 		if err != nil {
@@ -550,10 +557,17 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 			return
 		}
 
+		_, environment, err := defaultEnvironmentForProject(ctx, *r.client, data.ProjectId.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get default environment, got error: %s", err))
+			return
+		}
+
 		volumeResponse, err := createVolume(ctx, *r.client, VolumeCreateInput{
-			MountPath: volumeData.MountPath.ValueString(),
-			ProjectId: data.ProjectId.ValueString(),
-			ServiceId: data.Id.ValueStringPointer(),
+			MountPath:     volumeData.MountPath.ValueString(),
+			ProjectId:     data.ProjectId.ValueString(),
+			ServiceId:     data.Id.ValueStringPointer(),
+			EnvironmentId: &environment.Id,
 		})
 
 		if err != nil {


### PR DESCRIPTION
## Description

Fixes #61

This PR fixes a critical bug where volumes created via the `railway_service` resource were not being properly initialized, causing Terraform to report "Provider produced inconsistent result after apply" errors.

## Problem

When creating a `railway_service` resource with a `volume` block, Terraform would report:

```
Error: Provider produced inconsistent result after apply
.volume: was cty.ObjectVal(...), but now null.
```
Investigation revealed that volumes were being created in Railway, but they had no associated `VolumeInstances`. This meant that when Terraform attempted to read back the volume state using `getAndBuildVolumeInstance`, it couldn't find any matching volume instances and would set the volume attribute to `null`, causing the inconsistency error.

## Root Cause

The `createVolume` GraphQL mutation was being called without the `environmentId` parameter. While the Railway API documentation states that omitting `environmentId` should "deploy to all environments," in practice this resulted in volumes being created without any `VolumeInstances` in any environment.

The `createVolume` mutation would succeed and return a `Volume` object, but the `volumeInstances` edges array would be empty. Subsequent queries via `getAndBuildVolumeInstance` would also fail to find the volume instances because they were never actually created.

## Solution

The fix follows the established pattern used throughout the codebase for determining environment context. Similar to `getAndBuildServiceInstance` and `getAndBuildVolumeInstance`, we now:

1. Call `defaultEnvironmentForProject()` to retrieve the default environment for the project
2. Explicitly pass `EnvironmentId` to the `createVolume` mutation

This ensures that `VolumeInstances` are properly created in the correct environment and can be discovered by the existing read logic.

## Changes

- Added environment lookup using `defaultEnvironmentForProject()` in both `Create()` and `Update()` functions before calling `createVolume`
- Added `EnvironmentId: &environment.Id` parameter to `VolumeCreateInput` struct initialization

## Testing

This fix has been tested with real Railway infrastructure:
- Volumes are now created with proper `VolumeInstances`
- Terraform apply completes successfully without inconsistent state errors
- Volume state is correctly read back after creation

## Related Code

The fix follows the same pattern established in:
- `getAndBuildServiceInstance()` (line 752) - uses `defaultEnvironmentForProject()` to get environment context
- `getAndBuildVolumeInstance()` - queries volumes using environment context