### PR TITLE
feat: add retry logic for rate limiting and transient errors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,20 @@ There are several ways to provide the required token:
 * **Set the `token` argument in the provider configuration**. You can set the `token` argument in the provider configuration. Use an input variable for the token.
 * **Set the `RAILWAY_TOKEN` environment variable**. The provider can read the `RAILWAY_TOKEN` environment variable and the token stored there to authenticate.
 
+## Rate Limiting and Retry Behavior
+
+The provider automatically handles rate limiting and transient errors from the Railway API:
+
+* **HTTP 429 (Too Many Requests)**: Automatically retried with exponential backoff
+* **HTTP 502, 503, 504**: Transient server errors are automatically retried
+* **GraphQL rate limit errors**: Errors like "creating volumes too quickly" are automatically retried
+
+Retry behavior uses sensible defaults:
+* Maximum retries: 5
+* Initial backoff: 1 second
+* Maximum backoff: 30 seconds
+* Respects `Retry-After` headers when present
+
 ## Example Usage
 
 ```terraform

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -1,6 +1,25 @@
 package provider
 
-import "net/http"
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	// Default retry configuration
+	defaultMaxRetries     = 5
+	defaultInitialBackoff = 1 * time.Second
+	defaultMaxBackoff     = 30 * time.Second
+)
 
 type authedTransport struct {
 	token   string
@@ -11,4 +30,231 @@ func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", "Bearer "+t.token)
 
 	return t.wrapped.RoundTrip(req)
+}
+
+// retryTransport wraps an http.RoundTripper and adds retry logic for 429 and 5xx responses
+type retryTransport struct {
+	wrapped http.RoundTripper
+}
+
+// NewRetryTransport creates a new retry transport
+func NewRetryTransport(wrapped http.RoundTripper) http.RoundTripper {
+	return &retryTransport{
+		wrapped: wrapped,
+	}
+}
+
+// isRetryableStatusCode checks if the HTTP status code should trigger a retry
+func isRetryableStatusCode(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, // 429
+		http.StatusBadGateway,         // 502
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout:     // 504
+		return true
+	default:
+		return false
+	}
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; attempt <= defaultMaxRetries; attempt++ {
+		// Clone request body for retry if needed
+		if req.Body != nil && attempt > 0 && req.GetBody != nil {
+			newBody, err := req.GetBody()
+			if err != nil {
+				return nil, err
+			}
+			req.Body = newBody
+		}
+		if req.Body != nil && req.GetBody == nil {
+			bodyBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			req.Body = io.NopCloser(&bodyReader{data: bodyBytes})
+			bodyCopy := bodyBytes
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(&bodyReader{data: bodyCopy}), nil
+			}
+		}
+
+		resp, err = t.wrapped.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if !isRetryableStatusCode(resp.StatusCode) {
+			return resp, nil
+		}
+
+		if attempt == defaultMaxRetries {
+			break
+		}
+
+		backoff := calculateBackoff(attempt, resp)
+
+		tflog.Warn(ctx, "Retryable HTTP error from Railway API, retrying",
+			map[string]interface{}{
+				"attempt":     attempt + 1,
+				"max_retries": defaultMaxRetries,
+				"backoff_ms":  backoff.Milliseconds(),
+				"status_code": resp.StatusCode,
+			})
+
+		resp.Body.Close()
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	return resp, nil
+}
+
+// calculateBackoff determines the backoff duration for a retry attempt
+func calculateBackoff(attempt int, resp *http.Response) time.Duration {
+	// Check for Retry-After header
+	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+		if seconds, err := strconv.ParseInt(retryAfter, 10, 64); err == nil {
+			return time.Duration(seconds) * time.Second
+		}
+		if parsedTime, err := http.ParseTime(retryAfter); err == nil {
+			return time.Until(parsedTime)
+		}
+	}
+
+	// Exponential backoff: initialBackoff * 2^attempt
+	backoff := float64(defaultInitialBackoff) * math.Pow(2, float64(attempt))
+
+	if backoff > float64(defaultMaxBackoff) {
+		backoff = float64(defaultMaxBackoff)
+	}
+
+	return time.Duration(backoff)
+}
+
+// bodyReader is a simple io.Reader that reads from a byte slice
+type bodyReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *bodyReader) Read(p []byte) (n int, err error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// GraphQL-level retry patterns
+
+var graphQLRetryablePatterns = []string{
+	// Rate limiting
+	"too quickly",
+	"try again in a sec",
+	"rate limit",
+	"rate-limit",
+	"throttl",
+	"whoa there",
+	// Gateway errors
+	"504 gateway timeout",
+	"502 bad gateway",
+	"503 service unavailable",
+	"gateway timeout",
+	"bad gateway",
+	"service unavailable",
+	"connection reset",
+	"connection refused",
+}
+
+// IsRetryableGraphQLError checks if an error should trigger a retry
+func IsRetryableGraphQLError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := strings.ToLower(err.Error())
+	for _, pattern := range graphQLRetryablePatterns {
+		if strings.Contains(errMsg, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// RetryableClient wraps a graphql.Client with retry logic
+type RetryableClient struct {
+	client graphql.Client
+}
+
+// NewRetryableClient creates a new RetryableClient
+func NewRetryableClient(client graphql.Client) *RetryableClient {
+	return &RetryableClient{
+		client: client,
+	}
+}
+
+// MakeRequest implements graphql.Client interface with retry logic
+func (c *RetryableClient) MakeRequest(ctx context.Context, req *graphql.Request, resp *graphql.Response) error {
+	var lastErr error
+
+	for attempt := 0; attempt <= defaultMaxRetries; attempt++ {
+		err := c.client.MakeRequest(ctx, req, resp)
+
+		if err == nil && resp != nil && len(resp.Errors) > 0 {
+			err = fmt.Errorf("%v", resp.Errors)
+		}
+
+		if err == nil {
+			return nil
+		}
+
+		if !IsRetryableGraphQLError(err) {
+			return err
+		}
+
+		lastErr = err
+
+		if attempt == defaultMaxRetries {
+			break
+		}
+
+		backoff := calculateGraphQLBackoff(attempt)
+
+		tflog.Warn(ctx, "Retryable GraphQL error detected, retrying",
+			map[string]interface{}{
+				"attempt":     attempt + 1,
+				"max_retries": defaultMaxRetries,
+				"backoff_ms":  backoff.Milliseconds(),
+				"error":       err.Error(),
+			})
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	return fmt.Errorf("max retries exceeded: %w", lastErr)
+}
+
+// calculateGraphQLBackoff determines the backoff duration for a retry attempt
+func calculateGraphQLBackoff(attempt int) time.Duration {
+	backoff := float64(defaultInitialBackoff) * math.Pow(2, float64(attempt))
+
+	if backoff > float64(defaultMaxBackoff) {
+		backoff = float64(defaultMaxBackoff)
+	}
+
+	return time.Duration(backoff)
 }

--- a/internal/provider/client_test.go
+++ b/internal/provider/client_test.go
@@ -1,0 +1,222 @@
+package provider
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func TestRetryTransport_429Retry(t *testing.T) {
+	attempts := atomic.Int32{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt := attempts.Add(1)
+		if attempt < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":{}}`))
+	}))
+	defer server.Close()
+
+	transport := NewRetryTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("POST", server.URL, nil)
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if attempts.Load() != 3 {
+		t.Fatalf("expected 3 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestRetryTransport_5xxRetry(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"502 Bad Gateway", http.StatusBadGateway},
+		{"503 Service Unavailable", http.StatusServiceUnavailable},
+		{"504 Gateway Timeout", http.StatusGatewayTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := atomic.Int32{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				attempt := attempts.Add(1)
+				if attempt < 2 {
+					w.WriteHeader(tt.statusCode)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"data":{}}`))
+			}))
+			defer server.Close()
+
+			transport := NewRetryTransport(http.DefaultTransport)
+			client := &http.Client{Transport: transport}
+
+			req, _ := http.NewRequest("POST", server.URL, nil)
+			resp, err := client.Do(req)
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", resp.StatusCode)
+			}
+			if attempts.Load() != 2 {
+				t.Fatalf("expected 2 attempts, got %d", attempts.Load())
+			}
+		})
+	}
+}
+
+func TestRetryTransport_NoRetryOn400(t *testing.T) {
+	attempts := atomic.Int32{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	transport := NewRetryTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("POST", server.URL, nil)
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", resp.StatusCode)
+	}
+	if attempts.Load() != 1 {
+		t.Fatalf("expected 1 attempt (no retry), got %d", attempts.Load())
+	}
+}
+
+func TestRetryTransport_MaxRetriesExceeded(t *testing.T) {
+	attempts := atomic.Int32{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	transport := NewRetryTransport(http.DefaultTransport)
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("POST", server.URL, nil)
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected status 429, got %d", resp.StatusCode)
+	}
+	// Should be maxRetries + 1 (initial + retries)
+	if attempts.Load() != defaultMaxRetries+1 {
+		t.Fatalf("expected %d attempts, got %d", defaultMaxRetries+1, attempts.Load())
+	}
+}
+
+func TestIsRetryableStatusCode(t *testing.T) {
+	tests := []struct {
+		code     int
+		expected bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusForbidden, false},
+		{http.StatusNotFound, false},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, false},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+	}
+
+	for _, tt := range tests {
+		result := isRetryableStatusCode(tt.code)
+		if result != tt.expected {
+			t.Errorf("isRetryableStatusCode(%d) = %v, expected %v", tt.code, result, tt.expected)
+		}
+	}
+}
+
+func TestIsRetryableGraphQLError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "rate limit error",
+			err:      gqlerror.List{{Message: "Rate limit exceeded"}},
+			expected: true,
+		},
+		{
+			name:     "too quickly error",
+			err:      gqlerror.List{{Message: "creating volumes too quickly, please try again later"}},
+			expected: true,
+		},
+		{
+			name:     "5xx error message",
+			err:      gqlerror.List{{Message: "502 Bad Gateway"}},
+			expected: true,
+		},
+		{
+			name:     "503 error",
+			err:      gqlerror.List{{Message: "503 Service Unavailable"}},
+			expected: true,
+		},
+		{
+			name:     "504 error",
+			err:      gqlerror.List{{Message: "504 Gateway Timeout"}},
+			expected: true,
+		},
+		{
+			name:     "validation error",
+			err:      gqlerror.List{{Message: "Variable $id is required"}},
+			expected: false,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("some random error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRetryableGraphQLError(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsRetryableGraphQLError() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -80,14 +80,22 @@ func (p *RailwayProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	httpClient := http.Client{
-		Transport: &authedTransport{
+	// Build transport chain: retry -> auth -> default
+	transport := NewRetryTransport(
+		&authedTransport{
 			token:   token,
 			wrapped: http.DefaultTransport,
 		},
+	)
+
+	httpClient := http.Client{
+		Transport: transport,
 	}
 
-	client := graphql.NewClient("https://backboard.railway.app/graphql/v2?source=terraform_provider_railway", &httpClient)
+	baseClient := graphql.NewClient("https://backboard.railway.app/graphql/v2?source=terraform_provider_railway", &httpClient)
+
+	// Wrap with retry logic for GraphQL-level errors
+	var client graphql.Client = NewRetryableClient(baseClient)
 
 	resp.DataSourceData = &client
 	resp.ResourceData = &client

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -17,6 +17,20 @@ There are several ways to provide the required token:
 * **Set the `token` argument in the provider configuration**. You can set the `token` argument in the provider configuration. Use an input variable for the token.
 * **Set the `RAILWAY_TOKEN` environment variable**. The provider can read the `RAILWAY_TOKEN` environment variable and the token stored there to authenticate.
 
+## Rate Limiting and Retry Behavior
+
+The provider automatically handles rate limiting and transient errors from the Railway API:
+
+* **HTTP 429 (Too Many Requests)**: Automatically retried with exponential backoff
+* **HTTP 502, 503, 504**: Transient server errors are automatically retried
+* **GraphQL rate limit errors**: Errors like "creating volumes too quickly" are automatically retried
+
+Retry behavior uses sensible defaults:
+* Maximum retries: 5
+* Initial backoff: 1 second
+* Maximum backoff: 30 seconds
+* Respects `Retry-After` headers when present
+
 ## Example Usage
 
 {{ tffile "examples/provider/provider.tf" }}


### PR DESCRIPTION
## Summary

This PR adds automatic retry with exponential backoff for rate limiting (429) and transient server errors (5xx) at both HTTP and GraphQL levels.

## Changes

### HTTP Transport Level
Retries automatically on:
- 429 Too Many Requests (rate limiting)
- 502 Bad Gateway
- 503 Service Unavailable  
- 504 Gateway Timeout

### GraphQL Level
Retries automatically on:
- Rate limit errors (e.g., 'creating volumes too quickly')
- 5xx errors in GraphQL error messages

### Configuration
All values are fixed (no configuration options):
- Maximum retries: 5
- Initial backoff: 1 second
- Maximum backoff: 30 seconds
- Respects Retry-After headers when present

## Testing

Added comprehensive unit tests for HTTP and GraphQL retry behavior.

## Motivation

Addresses #63 - Improves reliability when Railway's API experiences high load or temporary outages.

## Notes

This is a simplified version based on maintainer feedback. Jitter has been removed, and there are no configuration options - just sensible defaults that work out of the box.
