### PR TITLE
Apply region and replica changes on service update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Add support for `target_port` in `railway_custom_domain` resource
 * Added `verification_host_label` and `verification_record_value` to `railway_custom_domain` resource
 
+### Bug fixes
+* Fixes `regions` and `num_replicas` changes being ignored when updating a `railway_service`
+
 ## 0.6.1
 
 ### Bug fixes

--- a/internal/provider/resource_service.go
+++ b/internal/provider/resource_service.go
@@ -486,6 +486,12 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	resp.Diagnostics.Append(data.Regions.ElementsAs(ctx, &regionsData, true)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_service_test.go
+++ b/internal/provider/resource_service_test.go
@@ -394,6 +394,48 @@ func TestAccServiceResourceNonDefaultRegionsImage(t *testing.T) {
 	})
 }
 
+func TestAccServiceResourceRegionsUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with an explicit single-region replica count
+			{
+				Config: testAccServiceResourceConfigRegionReplicas("todo-app", 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("railway_service.test", "id", uuidRegex()),
+					resource.TestCheckResourceAttr("railway_service.test", "name", "todo-app"),
+					resource.TestCheckResourceAttr("railway_service.test", "project_id", "0bb01547-570d-4109-a5e8-138691f6a2d1"),
+					resource.TestCheckResourceAttr("railway_service.test", "regions.0.region", "asia-southeast1-eqsg3a"),
+					resource.TestCheckResourceAttr("railway_service.test", "regions.0.num_replicas", "1"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "railway_service.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update the replica count in place. This is the path that previously
+			// dropped the change and produced an inconsistent-result error.
+			{
+				Config: testAccServiceResourceConfigRegionReplicas("todo-app", 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("railway_service.test", "regions.0.region", "asia-southeast1-eqsg3a"),
+					resource.TestCheckResourceAttr("railway_service.test", "regions.0.num_replicas", "2"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "railway_service.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func TestAccServiceResourceNonDefaultVolume(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -558,6 +600,22 @@ resource "railway_service" "test" {
   ]
 }
 `, name)
+}
+
+func testAccServiceResourceConfigRegionReplicas(name string, replicas int) string {
+	return fmt.Sprintf(`
+resource "railway_service" "test" {
+  name = "%s"
+  project_id = "0bb01547-570d-4109-a5e8-138691f6a2d1"
+
+  regions = [
+    {
+      region = "asia-southeast1-eqsg3a"
+      num_replicas = %d
+    }
+  ]
+}
+`, name, replicas)
 }
 
 func testAccServiceResourceConfigNonDefaultRegionsImage(name string) string {


### PR DESCRIPTION
Fixes #78.

`Update` declared `regionsData` but never populated it from the plan, so `buildServiceInstanceInput` always received nil and omitted `multiRegionConfig` from the update. Region and `num_replicas` changes were silently dropped, and the post-apply read of the live deployment then conflicted with the planned value, producing the "inconsistent result after apply" error.

`Create` already reads `regionsData` from the plan. This does the same in `Update`.

Added `TestAccServiceResourceRegionsUpdate`, which creates a service with one replica and updates it to two. The existing service tests never change `num_replicas` on a stable service, which is why this went unnoticed.
