### PR TITLE
feat: support cloning environments

### DIFF
--- a/docs/resources/environment.md
+++ b/docs/resources/environment.md
@@ -3,12 +3,12 @@
 page_title: "railway_environment Resource - terraform-provider-railway"
 subcategory: ""
 description: |-
-  Railway environment.
+  Railway environment. Railway does not expose the create-only cloning inputs after creation, so imports cannot recover source_environment_id or a true skip_initial_deploys value; configuring either on an imported environment requires replacement.
 ---
 
 # railway_environment (Resource)
 
-Railway environment.
+Railway environment. Railway does not expose the create-only cloning inputs after creation, so imports cannot recover `source_environment_id` or a true `skip_initial_deploys` value; configuring either on an imported environment requires replacement.
 
 ## Example Usage
 
@@ -16,6 +16,13 @@ Railway environment.
 resource "railway_environment" "example" {
   name       = "staging"
   project_id = railway_project.example.id
+}
+
+resource "railway_environment" "cloned_preview" {
+  name                  = "preview"
+  project_id            = railway_project.example.id
+  source_environment_id = railway_project.example.default_environment.id
+  skip_initial_deploys  = true
 }
 ```
 
@@ -26,6 +33,11 @@ resource "railway_environment" "example" {
 
 - `name` (String) Name of the environment.
 - `project_id` (String) Identifier of the project the environment belongs to.
+
+### Optional
+
+- `skip_initial_deploys` (Boolean) Whether deployments should be skipped while creating the environment. Commonly used with `source_environment_id` when cloning an environment.
+- `source_environment_id` (String) Identifier of an environment whose services, volumes, configuration, and variables are copied into this environment.
 
 ### Read-Only
 

--- a/examples/resources/railway_environment/resource.tf
+++ b/examples/resources/railway_environment/resource.tf
@@ -2,3 +2,10 @@ resource "railway_environment" "example" {
   name       = "staging"
   project_id = railway_project.example.id
 }
+
+resource "railway_environment" "cloned_preview" {
+  name                  = "preview"
+  project_id            = railway_project.example.id
+  source_environment_id = railway_project.example.default_environment.id
+  skip_initial_deploys  = true
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"net/http"
 	"os"
 	"testing"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
@@ -20,4 +22,14 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("RAILWAY_TOKEN"); v == "" {
 		t.Fatal("RAILWAY_TOKEN must be set for acceptance tests")
 	}
+}
+
+func testAccClient() graphql.Client {
+	httpClient := http.Client{
+		Transport: &authedTransport{
+			token:   os.Getenv("RAILWAY_TOKEN"),
+			wrapped: http.DefaultTransport,
+		},
+	}
+	return graphql.NewClient("https://backboard.railway.app/graphql/v2?source=terraform_provider_railway", &httpClient)
 }

--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -29,9 +31,11 @@ type EnvironmentResource struct {
 }
 
 type EnvironmentResourceModel struct {
-	Id       types.String `tfsdk:"id"`
-	Name     types.String `tfsdk:"name"`
-	ProjecId types.String `tfsdk:"project_id"`
+	Id                  types.String `tfsdk:"id"`
+	Name                types.String `tfsdk:"name"`
+	ProjecId            types.String `tfsdk:"project_id"`
+	SourceEnvironmentId types.String `tfsdk:"source_environment_id"`
+	SkipInitialDeploys  types.Bool   `tfsdk:"skip_initial_deploys"`
 }
 
 func (r *EnvironmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -40,7 +44,7 @@ func (r *EnvironmentResource) Metadata(ctx context.Context, req resource.Metadat
 
 func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Railway environment.",
+		MarkdownDescription: "Railway environment. Railway does not expose the create-only cloning inputs after creation, so imports cannot recover `source_environment_id` or a true `skip_initial_deploys` value; configuring either on an imported environment requires replacement.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				MarkdownDescription: "Identifier of the environment.",
@@ -67,6 +71,25 @@ func (r *EnvironmentResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(uuidRegex(), "must be an id"),
+				},
+			},
+			"source_environment_id": schema.StringAttribute{
+				MarkdownDescription: "Identifier of an environment whose services, volumes, configuration, and variables are copied into this environment.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(uuidRegex(), "must be an id"),
+				},
+			},
+			"skip_initial_deploys": schema.BoolAttribute{
+				MarkdownDescription: "Whether deployments should be skipped while creating the environment. Commonly used with `source_environment_id` when cloning an environment.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
 				},
 			},
 		},
@@ -103,8 +126,10 @@ func (r *EnvironmentResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	input := EnvironmentCreateInput{
-		Name:      data.Name.ValueString(),
-		ProjectId: data.ProjecId.ValueString(),
+		Name:                data.Name.ValueString(),
+		ProjectId:           data.ProjecId.ValueString(),
+		SourceEnvironmentId: data.SourceEnvironmentId.ValueStringPointer(),
+		SkipInitialDeploys:  data.SkipInitialDeploys.ValueBool(),
 	}
 
 	response, err := createEnvironment(ctx, *r.client, input)
@@ -146,6 +171,9 @@ func (r *EnvironmentResource) Read(ctx context.Context, req resource.ReadRequest
 	data.Id = types.StringValue(environment.Id)
 	data.Name = types.StringValue(environment.Name)
 	data.ProjecId = types.StringValue(environment.ProjectId)
+	if data.SkipInitialDeploys.IsNull() || data.SkipInitialDeploys.IsUnknown() {
+		data.SkipInitialDeploys = types.BoolValue(false)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/resource_environment_test.go
+++ b/internal/provider/resource_environment_test.go
@@ -1,10 +1,13 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccEnvironmentResourceDefault(t *testing.T) {
@@ -42,6 +45,36 @@ func TestAccEnvironmentResourceDefault(t *testing.T) {
 	})
 }
 
+func TestAccEnvironmentResourceClone(t *testing.T) {
+	projectName := "tf-acc-env-clone-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentResourceConfigClone(projectName, "integration-clone"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("railway_project.test_clone", "id", uuidRegex()),
+					resource.TestMatchResourceAttr("railway_environment.test", "id", uuidRegex()),
+					resource.TestCheckResourceAttr("railway_environment.test", "name", "integration-clone"),
+					resource.TestCheckResourceAttrPair("railway_environment.test", "project_id", "railway_project.test_clone", "id"),
+					resource.TestCheckResourceAttrPair("railway_environment.test", "source_environment_id", "railway_project.test_clone", "default_environment.id"),
+					resource.TestCheckResourceAttr("railway_environment.test", "skip_initial_deploys", "true"),
+					testAccCheckClonedServiceWithoutDeployment,
+				),
+			},
+			{
+				ResourceName:            "railway_environment.test",
+				ImportState:             true,
+				ImportStateIdFunc:       testAccEnvironmentCloneImportStateId,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source_environment_id", "skip_initial_deploys"},
+			},
+		},
+	})
+}
+
 func testAccEnvironmentResourceConfigDefault(name string) string {
 	return fmt.Sprintf(`
 resource "railway_environment" "test" {
@@ -49,4 +82,61 @@ resource "railway_environment" "test" {
   project_id = "0bb01547-570d-4109-a5e8-138691f6a2d1"
 }
 `, name)
+}
+
+func testAccEnvironmentResourceConfigClone(projectName string, name string) string {
+	return fmt.Sprintf(`
+resource "railway_project" "test_clone" {
+  name = "%s"
+}
+
+resource "railway_service" "clone_source" {
+  name         = "clone-source"
+  project_id   = railway_project.test_clone.id
+  source_image = "traefik/whoami:v1.10"
+}
+
+resource "railway_environment" "test" {
+  name                  = "%s"
+  project_id            = railway_project.test_clone.id
+  source_environment_id = railway_project.test_clone.default_environment.id
+  skip_initial_deploys  = true
+
+  depends_on = [railway_service.clone_source]
+}
+`, projectName, name)
+}
+
+func testAccCheckClonedServiceWithoutDeployment(state *terraform.State) error {
+	environment := state.RootModule().Resources["railway_environment.test"]
+	service := state.RootModule().Resources["railway_service.clone_source"]
+
+	response, err := getServiceInstance(
+		context.Background(),
+		testAccClient(),
+		environment.Primary.ID,
+		service.Primary.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("read cloned service instance: %w", err)
+	}
+
+	instance := response.ServiceInstance
+	if instance.Source == nil || instance.Source.Image == nil ||
+		*instance.Source.Image != "traefik/whoami:v1.10" {
+		return fmt.Errorf("cloned service source image was not preserved")
+	}
+	if instance.LatestDeployment.Meta != nil {
+		return fmt.Errorf("cloned service unexpectedly received an initial deployment")
+	}
+	return nil
+}
+
+func testAccEnvironmentCloneImportStateId(state *terraform.State) (string, error) {
+	resourceState := state.RootModule().Resources["railway_environment.test"]
+	return fmt.Sprintf(
+		"%s:%s",
+		resourceState.Primary.Attributes["project_id"],
+		resourceState.Primary.Attributes["name"],
+	), nil
 }


### PR DESCRIPTION
Adds `source_environment_id` and `skip_initial_deploys` to `railway_environment`, allowing an environment to be cloned while optionally suppressing initial deployments.

Includes generated documentation, examples for regular and cloned environments, and acceptance coverage for cloning and import.

The acceptance test creates an isolated Railway project, populates its default environment with a service, verifies that cloning copies the service configuration without starting a deployment, verifies import behavior, and destroys the complete project fixture afterward.