### PR TITLE
Omit unmanaged fields from ServiceInstanceUpdateInput

### DIFF
--- a/internal/provider/generated.go
+++ b/internal/provider/generated.go
@@ -504,15 +504,15 @@ type ServiceInstanceUpdateInput struct {
 	BuildCommand            *string                   `json:"buildCommand,omitempty"`
 	Builder                 *Builder                  `json:"builder,omitempty"`
 	CronSchedule            *string                   `json:"cronSchedule"`
-	DockerfilePath          string                    `json:"dockerfilePath"`
-	DrainingSeconds         int                       `json:"drainingSeconds"`
+	DockerfilePath          *string                   `json:"dockerfilePath,omitempty"`
+	DrainingSeconds         *int                      `json:"drainingSeconds,omitempty"`
 	HealthcheckPath         *string                   `json:"healthcheckPath,omitempty"`
 	HealthcheckTimeout      *int                      `json:"healthcheckTimeout,omitempty"`
-	Ipv6EgressEnabled       bool                      `json:"ipv6EgressEnabled"`
+	Ipv6EgressEnabled       *bool                     `json:"ipv6EgressEnabled,omitempty"`
 	MultiRegionConfig       *map[string]interface{}   `json:"multiRegionConfig,omitempty"`
 	NixpacksPlan            *map[string]interface{}   `json:"nixpacksPlan,omitempty"`
 	NumReplicas             *int                      `json:"numReplicas,omitempty"`
-	OverlapSeconds          int                       `json:"overlapSeconds"`
+	OverlapSeconds          *int                      `json:"overlapSeconds,omitempty"`
 	PreDeployCommand        *[]string                 `json:"preDeployCommand,omitempty"`
 	RailwayConfigFile       *string                   `json:"railwayConfigFile,omitempty"`
 	Region                  *string                   `json:"region,omitempty"`
@@ -536,10 +536,10 @@ func (v *ServiceInstanceUpdateInput) GetBuilder() *Builder { return v.Builder }
 func (v *ServiceInstanceUpdateInput) GetCronSchedule() *string { return v.CronSchedule }
 
 // GetDockerfilePath returns ServiceInstanceUpdateInput.DockerfilePath, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetDockerfilePath() string { return v.DockerfilePath }
+func (v *ServiceInstanceUpdateInput) GetDockerfilePath() *string { return v.DockerfilePath }
 
 // GetDrainingSeconds returns ServiceInstanceUpdateInput.DrainingSeconds, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetDrainingSeconds() int { return v.DrainingSeconds }
+func (v *ServiceInstanceUpdateInput) GetDrainingSeconds() *int { return v.DrainingSeconds }
 
 // GetHealthcheckPath returns ServiceInstanceUpdateInput.HealthcheckPath, and is useful for accessing the field via an interface.
 func (v *ServiceInstanceUpdateInput) GetHealthcheckPath() *string { return v.HealthcheckPath }
@@ -548,7 +548,7 @@ func (v *ServiceInstanceUpdateInput) GetHealthcheckPath() *string { return v.Hea
 func (v *ServiceInstanceUpdateInput) GetHealthcheckTimeout() *int { return v.HealthcheckTimeout }
 
 // GetIpv6EgressEnabled returns ServiceInstanceUpdateInput.Ipv6EgressEnabled, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetIpv6EgressEnabled() bool { return v.Ipv6EgressEnabled }
+func (v *ServiceInstanceUpdateInput) GetIpv6EgressEnabled() *bool { return v.Ipv6EgressEnabled }
 
 // GetMultiRegionConfig returns ServiceInstanceUpdateInput.MultiRegionConfig, and is useful for accessing the field via an interface.
 func (v *ServiceInstanceUpdateInput) GetMultiRegionConfig() *map[string]interface{} {
@@ -562,7 +562,7 @@ func (v *ServiceInstanceUpdateInput) GetNixpacksPlan() *map[string]interface{} {
 func (v *ServiceInstanceUpdateInput) GetNumReplicas() *int { return v.NumReplicas }
 
 // GetOverlapSeconds returns ServiceInstanceUpdateInput.OverlapSeconds, and is useful for accessing the field via an interface.
-func (v *ServiceInstanceUpdateInput) GetOverlapSeconds() int { return v.OverlapSeconds }
+func (v *ServiceInstanceUpdateInput) GetOverlapSeconds() *int { return v.OverlapSeconds }
 
 // GetPreDeployCommand returns ServiceInstanceUpdateInput.PreDeployCommand, and is useful for accessing the field via an interface.
 func (v *ServiceInstanceUpdateInput) GetPreDeployCommand() *[]string { return v.PreDeployCommand }

--- a/internal/provider/resource_service.graphql
+++ b/internal/provider/resource_service.graphql
@@ -94,6 +94,10 @@ query getServiceInstances(
 # @genqlient(for: "ServiceInstanceUpdateInput.restartPolicyType", omitempty: true, pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.restartPolicyMaxRetries", omitempty: true, pointer: true)
 # @genqlient(for: "ServiceInstanceUpdateInput.sleepApplication", omitempty: true, pointer: true)
+# @genqlient(for: "ServiceInstanceUpdateInput.dockerfilePath", omitempty: true, pointer: true)
+# @genqlient(for: "ServiceInstanceUpdateInput.drainingSeconds", omitempty: true, pointer: true)
+# @genqlient(for: "ServiceInstanceUpdateInput.overlapSeconds", omitempty: true, pointer: true)
+# @genqlient(for: "ServiceInstanceUpdateInput.ipv6EgressEnabled", omitempty: true, pointer: true)
 mutation updateServiceInstance(
   $serviceId: String!
   $input: ServiceInstanceUpdateInput!


### PR DESCRIPTION
Fixes #91.

Four fields of `ServiceInstanceUpdateInput` have no genqlient directive, so they generate as bare value types and marshal on every write:

```go
DockerfilePath    string  `json:"dockerfilePath"`      // sends ""
DrainingSeconds   int     `json:"drainingSeconds"`     // sends 0
OverlapSeconds    int     `json:"overlapSeconds"`      // sends 0
Ipv6EgressEnabled bool    `json:"ipv6EgressEnabled"`   // sends false
```

`railway_service` exposes no attribute for any of them, and nothing in the provider ever assigns them, so these values are always zero and always sent. `Create()` and `Update()` both send the struct wholesale, so any apply that touches a service resets all four on the API side, with no sign of it in the plan, the apply output, or the next plan.

This adds the four directives that every sibling field already carries. All four are nullable in `schema.graphql`, so nothing else has to change.

`cronSchedule` is left as it is. It has `pointer: true` without `omitempty`, and since `railway_service` does expose `cron_schedule`, the explicit null is how a removed schedule gets cleared. Adding `omitempty` there would break that, which is why it is not in this change.

### How it showed up

An apply that changed only `source_repo_branch` set `dockerfilePath` from null to `""` on two services whose repository has no Dockerfile. Railway derives the Dockerfile builder from a non-null path, so every build after that died during driver selection with no build output, retried across three or four builders, then failed. The same write reset `drainingSeconds` from 120 to 0. Recovery needed `environmentPatchCommit` against the environment config document, since `serviceInstanceUpdate` ignores an explicit null on these fields.

### On the generated file

I do not have a Go toolchain on this machine, so I could not run `go generate` or build. The `generated.go` hunk was written by hand to match exactly what the four directives produce, following the shape of the existing pointer fields, and I checked that none of the four fields is referenced anywhere outside `generated.go`, so no call site needs updating. Please re-run `go generate` to confirm it reproduces byte for byte before merging.
